### PR TITLE
fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The models provided with the sample recognizes some foods(Cheesecake, Donuts, Fr
 
 ### Things to note.
 - Image preprocessing is performed by binding method call. Look at method "EvaluateAsync" of class "OnnxModel". Note that it binds a VideoFrame instance to "data"; this binding call will perform cropping and scaling such that the image fits the define size of model (224 x 224 with included models). It will also reformat the image data into a tensor that the model expects(Channel(BGR), Rows, Cols).
-- mlgen.exe - This tool generates API code in c# or c++ for a specified ONNX mode.  See [Windows ML overview](https://docs.microsoft.com/en-us/windows/uwp/machine-learning/overview) for description of utility. If you are working with a ONNX model and are unsure what variable types to utilize this utility will generate the correct types.
+- mlgen.exe - This tool generates API code in c# or c++ for a specified ONNX model.  See [Windows ML overview](https://docs.microsoft.com/en-us/windows/uwp/machine-learning/overview) for description of utility. If you are working with a ONNX model and are unsure what variable types to utilize this utility will generate the correct types.
 
 ## Resources
 - Link to [ONNX](https://onnx.ai/)


### PR DESCRIPTION
- Replace `mode` with `model`


## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* To fix a typo in [README.md](https://github.com/Azure-Samples/cognitive-services-onnx-customvision-sample/blob/master/README.md) that could be confusing to some.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe: 
```

## How to Test
Not required

## What to Check
Verify that the following are valid
* `mode` is meant to be `model` and is not intentionally written as `mode`

## Other Information
<!-- Add any other helpful information that may be needed here. -->
None